### PR TITLE
Content Cleaner for About page

### DIFF
--- a/about_page_content_cleaner.py
+++ b/about_page_content_cleaner.py
@@ -1,0 +1,62 @@
+import re
+from bento.common.utils import get_logger
+
+logger = get_logger('AboutPageContentCleaner')
+
+
+class AboutPageContentCleaner:
+    @staticmethod
+    def clean_text(text):
+        # Remove inline links
+        cleaned_text = re.sub(r'\$\$\[(.*?)\]\(.*?\)\$\$', r'\1', text)
+        # Remove hash tags
+        cleaned_text = re.sub(r'\$\$#(.*?)#\$\$', r'\1', cleaned_text)
+        # Remove asterisk symbol
+        cleaned_text = re.sub(r'\$\$\*(.*?)\*\$\$', r'\1', cleaned_text)
+        # Remove extra spaces
+        cleaned_text = ' '.join(cleaned_text.split())
+        return cleaned_text
+
+    @staticmethod
+    def remove_formatting_content(page_name, content):
+        cleaned_content = []
+        for item in content:
+            if isinstance(item, dict) and 'paragraph' in item:
+                item['paragraph'] = AboutPageContentCleaner.clean_text(item['paragraph'])
+                cleaned_content.append(item)
+            # Handling unOrdered List
+            elif isinstance(item, dict) and 'listWithDots' in item:
+                cleaned_list = []
+                for list_item in item['listWithDots']:
+                    # handling Alphabets sub orders list
+                    if 'listWithAlphabets' in list_item:
+                        cleaned_inner_list = [AboutPageContentCleaner.clean_text(inner_list_item) for inner_list_item in list_item['listWithAlphabets']]
+                        cleaned_list.append({'listWithAlphabets': cleaned_inner_list})
+                    else:
+                        cleaned_list.append(AboutPageContentCleaner.clean_text(list_item))
+                cleaned_content.append({'listWithDots': cleaned_list})
+            elif isinstance(item, dict) and 'listWithAlphabets' in item:
+                cleaned_list = [AboutPageContentCleaner.clean_text(list_item) for list_item in item['listWithAlphabets']]
+                cleaned_content.append({'listWithAlphabets': cleaned_list})
+            # Handling Ordered List with Numbers
+            elif isinstance(item, dict) and 'listWithNumbers' in item:
+                cleaned_list = []
+                for list_item in item['listWithNumbers']:
+                    # Handling Alphabets sub orders list
+                    if 'listWithAlphabets' in list_item:
+                        cleaned_inner_list = [AboutPageContentCleaner.clean_text(inner_list_item) for inner_list_item in list_item['listWithAlphabets']]
+                        cleaned_list.append({'listWithAlphabets': cleaned_inner_list})
+                    else:
+                        cleaned_list.append(AboutPageContentCleaner.clean_text(list_item))
+                cleaned_content.append({'listWithNumbers': cleaned_list})
+            # Handle table cleaning logic
+            elif isinstance(item, dict) and 'table' in item:
+                cleaned_table = {
+                    'head': [AboutPageContentCleaner.clean_text(cell) for cell in item['table']['head']],
+                    'body': [[AboutPageContentCleaner.clean_text(cell) for cell in row] for row in item['table']['body']]
+                }
+                cleaned_content.append({'table': cleaned_table})
+            else:
+                cleaned_content.append(item)
+        logger.info(f'Cleaned content for "{page_name}"')
+        return cleaned_content

--- a/config/es_loader.example.yml
+++ b/config/es_loader.example.yml
@@ -1,6 +1,6 @@
 Config:
   # Neo4j URL with port number
-  neo4j_uri: "bolt://127.0.0.1:7687"
+  neo4j_uri: 'bolt://127.0.0.1:7687'
   # Neo4j user name, default is neo4j
   neo4j_user: neo4j
   # Password for Neo4j user
@@ -9,6 +9,8 @@ Config:
   es_host: localhost
   # Path to about file
   about_file: path_to_about_yaml_file
+  # Boolean flag indicating whether to apply formatting cleaning to the content from the about/static page.
+  clean_about_page_format: True
 
   model_files:
     - bento-model/model-desc/bento_tailorx_model_file.yaml

--- a/es_loader.py
+++ b/es_loader.py
@@ -13,6 +13,8 @@ from neo4j import GraphDatabase
 from bento.common.utils import get_logger, print_config
 from icdc_schema import ICDC_Schema, PROPERTIES, ENUM, PROP_ENUM, PROP_TYPE, REQUIRED, DESCRIPTION
 from props import Props
+from about_page_content_cleaner import AboutPageContentCleaner
+
 
 logger = get_logger('ESLoader')
 
@@ -111,22 +113,8 @@ class ESLoader:
                 self.index_data(index_name, page, f'page{page["page"]}')
     
     def remove_formatting_content(self, page_name, content):
-        cleaned_content = []
-        for item in content:
-            if isinstance(item, dict) and 'paragraph' in item:
-                # Remove inline links
-                cleaned_text = re.sub(r'\$\$\[(.*?)\]\(.*?\)\$\$', r'\1', item['paragraph'])
-                # Remove hash tags
-                cleaned_text = re.sub(r'\$\$#(.*?)#\$\$', r'\1', cleaned_text)
-                # Remove asterisk symbol
-                cleaned_text = re.sub(r'\$\$\*(.*?)\*\$\$', r'\1', cleaned_text)
-                # Remove extra spaces
-                cleaned_text = ' '.join(cleaned_text.split())
-                cleaned_content.append({'paragraph': cleaned_text})
-            else:
-                cleaned_content.append(item)
-        logger.info(f'Cleaned content for "{page_name}"')
-        return cleaned_content
+        # Call remove_formatting_content from AboutPageContentCleaner
+        return AboutPageContentCleaner.remove_formatting_content(page_name, content)
     
     def read_model(self, model_files, prop_file):
         for file_name in model_files:

--- a/es_loader.py
+++ b/es_loader.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 
-import re
 import os
 import yaml
 from elasticsearch import Elasticsearch, RequestsHttpConnection
@@ -14,7 +13,6 @@ from bento.common.utils import get_logger, print_config
 from icdc_schema import ICDC_Schema, PROPERTIES, ENUM, PROP_ENUM, PROP_TYPE, REQUIRED, DESCRIPTION
 from props import Props
 from about_page_content_cleaner import AboutPageContentCleaner
-
 
 logger = get_logger('ESLoader')
 


### PR DESCRIPTION
This update introduces a feature to clean the content of about pages, ensuring that it's free from any formatting added for display purposes on the frontend. The cleaning process removes unnecessary formatting elements, including inline links, hash tags, asterisks, and extra spaces. The cleaned content will then be utilized by the Global Search page to display search results accurately.

**Usage**: The functionality can be enabled or disabled by setting a boolean value `clean_about_page_format`. When enabled, the content cleaning process will be applied to the about page content.

Reported ticket: CTDC-1455